### PR TITLE
19 docker compose for dependencies database

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ Mono repo for mylecow app
 
 # Setup local dev environment
 
+## Create mylecow network
+
+Create mylecow network for developing
+```
+docker network create mylecow
+```
+
 ## (Re)-create IDE
 
 Run:
 ```
-docker run --pull always -d --name=mylecowide -e SUDO_PASSWORD=abc -e TZ=America/Bogota -p 8443:8443 -p 5173:5173 -p 3000:3000 -p 6006:6006 -v /var/run/docker.sock:/var/run/docker.sock -v mylecowide:/config --restart unless-stopped ksrarc/mylecow-ide
+docker run --pull always -d --name=mylecowide -e SUDO_PASSWORD=abc -e TZ=America/Bogota --network mylecow -p 8443:8443 -p 5173:5173 -p 3000:3000 -p 6006:6006 -v /var/run/docker.sock:/var/run/docker.sock -v mylecowide:/config --restart unless-stopped ksrarc/mylecow-ide
 ```
 
 ### First time manual setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,9 @@ services:
     environment:
       PGADMIN_DEFAULT_EMAIL: abc@example.com
       PGADMIN_DEFAULT_PASSWORD: abc
+    configs:
+      - source: servers.json
+        target: /pgadmin4/servers.json
     ports:
       - 8880:80
 
@@ -17,3 +20,30 @@ networks:
   default:
     name: mylecow
     external: true
+
+configs:
+  servers.json:
+    content: |
+      {
+        "Servers": {
+          "1": {
+            "Name": "db",
+            "Group": "Servers",
+            "Host": "db",
+            "Port": 5432,
+            "MaintenanceDB": "postgres",
+            "Username": "mylecow",
+            "UseSSHTunnel": 0,
+            "TunnelPort": "22",
+            "TunnelAuthentication": 0,
+            "KerberosAuthentication": false,
+            "ConnectionParameters": {
+                "sslmode": "prefer",
+                "connect_timeout": 10,
+                "sslcert": "<STORAGE_DIR>/.postgresql/postgresql.crt",
+                "sslkey": "<STORAGE_DIR>/.postgresql/postgresql.key"
+            },
+            "Tags": []
+          }
+        }
+      }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
       POSTGRES_PASSWORD: mylecow
       POSTGRES_DB: mylecow
       POSTGRES_USER: mylecow
-    ports:
-      - 5432:5432
   pgadmin:
     image: dpage/pgadmin4:9.1.0
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  db:
+    image: postgres:16.8-alpine3.20
+    environment:
+      POSTGRES_PASSWORD: mylecow
+      POSTGRES_DB: mylecow
+      POSTGRES_USER: mylecow
+    ports:
+      - 5432:5432
+  pgadmin:
+    image: dpage/pgadmin4:9.1.0
+    environment:
+      PGADMIN_DEFAULT_EMAIL: abc@example.com
+      PGADMIN_DEFAULT_PASSWORD: abc
+    ports:
+      - 8880:80
+
+networks:
+  default:
+    name: mylecow
+    external: true


### PR DESCRIPTION
Created docker compose at root level to handle backend dependencies.

1. IDE must be recreated following README.md instructions
2. bring up dependencies using `sudo docker compose up` command. Ctrl+C to stop them
3. pgadmin UI can be accessed at http://localhost:8880 with `abc@example.com` user and `abc` password
4. db server is preloaded into pgadmin, just provide and save the password. See `docker-compose.yml`